### PR TITLE
refactor: remove unused webhook handler

### DIFF
--- a/without-webhooks/server/node/server.js
+++ b/without-webhooks/server/node/server.js
@@ -6,17 +6,6 @@ const env = require("dotenv").config({ path: "./.env" });
 const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 
 app.use(express.static(process.env.STATIC_DIR));
-app.use(
-  express.json({
-    // We need the raw body to verify webhook signatures.
-    // Let's compute it only when hitting the Stripe webhook endpoint.
-    verify: function(req, res, buf) {
-      if (req.originalUrl.startsWith("/webhook")) {
-        req.rawBody = buf.toString();
-      }
-    }
-  })
-);
 
 app.get("/", (req, res) => {
   // Display checkout page


### PR DESCRIPTION
Remove handling of webhooks for `without-webhooks` example. Note that there's no other references to webhook inside the `without-webhooks` dir so this should be sufficient.