### PR TITLE
.env configuration step added to without-webhooks/server/python/README.md

### DIFF
--- a/without-webhooks/server/python/README.md
+++ b/without-webhooks/server/python/README.md
@@ -3,7 +3,6 @@
 ## Requirements
 
 - Python 3
-- [Configured .env file](../README.md)
 
 ## How to run
 
@@ -29,7 +28,23 @@ python3 -m venv env
 pip install -r requirements.txt
 ```
 
-3. Export and run the application
+3. Configure .env
+
+**MacOS / Unix**
+
+```
+cp dev.env .env
+nano .env # Set its keys
+```
+
+**Windows (PowerShell)**
+
+```
+Copy-Item ".\dev.env" -Destination ".\.env"
+# Set its keys in .env with any code editor
+```
+
+4. Export and run the application
 
 **MacOS / Unix**
 
@@ -45,4 +60,4 @@ $env:FLASK_APP=“server.py"
 python3 -m flask run --port=4242
 ```
 
-4. Go to `localhost:4242` in your browser to see the demo
+5. Go to `localhost:4242` in your browser to see the demo

--- a/without-webhooks/server/python/dev.env
+++ b/without-webhooks/server/python/dev.env
@@ -1,0 +1,4 @@
+STRIPE_SECRET_KEY=""
+STRIPE_PUBLISHABLE_KEY=""
+# STRIPE_API_VERSION="" # optional
+STATIC_DIR="../../client/web" # relative path to accept-a-card-payment/without-webhooks/client/web


### PR DESCRIPTION
On README.md when you click in "Configured .env file" it don't show relevant information.
This commit added a file `dev.env` as template and the instructions to copy and rename as `.env`