### PR TITLE
Remove unused clientSecret parameter

### DIFF
--- a/without-webhooks/client/web/script.js
+++ b/without-webhooks/client/web/script.js
@@ -16,13 +16,13 @@ fetch("/stripe-key")
   .then(function(data) {
     return setupElements(data);
   })
-  .then(function({ stripe, card, clientSecret }) {
+  .then(function({ stripe, card }) {
     document.querySelector("button").disabled = false;
 
     var form = document.getElementById("payment-form");
     form.addEventListener("submit", function(event) {
       event.preventDefault();
-      pay(stripe, card, clientSecret);
+      pay(stripe, card);
     });
   });
 
@@ -51,8 +51,7 @@ var setupElements = function(data) {
 
   return {
     stripe: stripe,
-    card: card,
-    clientSecret: data.clientSecret
+    card: card
   };
 };
 


### PR DESCRIPTION
The clientSecret variable is never used. It isn't even passed to the client from the server when fetching /stripe-key. It just adds confusion.