### PR TITLE
Change the location of server.js for npm start command at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Stripe card payment sample.",
   "main": "server.js",
   "scripts": {
-    "start": "node server/node/server.js",
+    "start": "node server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "stripe-samples",


### PR DESCRIPTION
According to [this issue](https://github.com/stripe/stripe-cli/issues/437) at the stripe-cli repository, the script for `npm start` at the `package.json` for `accept-a-card-payment` sample is pointing to the wrong path (`server/node/server.js`) whereas the `server.js` is located in the (`server/server.js`). 

I did some reading on the code and assume that the `stripe samples create` command for the `accept-a-card-payment` sample will clone from this repository so changing the `package.json` at the root of this repository will solve the problem. 