### PR TITLE
PHP Fix: Fix call to re-confirm PI after card action

### DIFF
--- a/without-webhooks/server/php/public/script.js
+++ b/without-webhooks/server/php/public/script.js
@@ -61,7 +61,7 @@ var handleAction = function(clientSecret) {
     if (data.error) {
       showError("Your card was not authenticated, please try again");
     } else if (data.paymentIntent.status === "requires_confirmation") {
-      fetch("/pay", {
+      fetch("/pay.php", {
         method: "POST",
         headers: {
           "Content-Type": "application/json"


### PR DESCRIPTION
The `fetch` to `/pay` unexpectedly returns an HTML page instead of the intended json and causes an error and stuck loading state after 3ds auth. This PR fixes this be replacing the URL with the correct one.

Reported by helpful user and passed through support channels after getting resolved.