### PR TITLE
Use Werkzeug 0.15.5 or newer to fix TypeError

### DIFF
--- a/decline-on-card-authentication/server/python/requirements.txt
+++ b/decline-on-card-authentication/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.29.3
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.4
+Werkzeug==1.0.1


### PR DESCRIPTION
Updated the library for the same reason as https://github.com/stripe-samples/subscription-use-cases/pull/57.