### PR TITLE
Use the latest API version to avoid TypeScript compilation errors

### DIFF
--- a/decline-on-card-authentication/server/node-typescript/package-lock.json
+++ b/decline-on-card-authentication/server/node-typescript/package-lock.json
@@ -677,11 +677,11 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stripe": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.0.1.tgz",
-      "integrity": "sha512-0D9r1YGkrNFmX6RRk34P0uslrOw4cuav1yuJVcxlIwwhh8R06XIqTTPU6/PeGvJ89SUTU/+jny8gFZU0MZ0rpg==",
+      "version": "8.121.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.121.0.tgz",
+      "integrity": "sha512-Uswmut57hVdyPrb+EJUTWbrLcTIEL4LS5T6UQZPO5AJNYT0PGHajgY1esQwmV7yVBL+Kgt3y/16zIAY/gAwifg==",
       "requires": {
-        "@types/node": "^13.1.0",
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       }
     },

--- a/decline-on-card-authentication/server/node-typescript/package.json
+++ b/decline-on-card-authentication/server/node-typescript/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "stripe": "^8.0.1"
+    "stripe": "^8.121.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/decline-on-card-authentication/server/node-typescript/src/server.ts
+++ b/decline-on-card-authentication/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import Stripe from "stripe";
 env.config({ path: "./.env" });
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2019-12-03",
+  apiVersion: "2020-08-27",
   typescript: true
 });
 

--- a/using-webhooks/server/node-typescript/package-lock.json
+++ b/using-webhooks/server/node-typescript/package-lock.json
@@ -82,8 +82,7 @@
     "@types/node": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
-      "dev": true
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -678,19 +677,12 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stripe": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.0.1.tgz",
-      "integrity": "sha512-0D9r1YGkrNFmX6RRk34P0uslrOw4cuav1yuJVcxlIwwhh8R06XIqTTPU6/PeGvJ89SUTU/+jny8gFZU0MZ0rpg==",
+      "version": "8.121.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.121.0.tgz",
+      "integrity": "sha512-Uswmut57hVdyPrb+EJUTWbrLcTIEL4LS5T6UQZPO5AJNYT0PGHajgY1esQwmV7yVBL+Kgt3y/16zIAY/gAwifg==",
       "requires": {
-        "@types/node": "^13.1.0",
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.1.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-          "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
-        }
       }
     },
     "supports-color": {

--- a/using-webhooks/server/node-typescript/package.json
+++ b/using-webhooks/server/node-typescript/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "stripe": "^8.0.1"
+    "stripe": "^8.121.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/using-webhooks/server/node-typescript/src/server.ts
+++ b/using-webhooks/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import express from "express";
 
 import Stripe from "stripe";
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2019-12-03",
+  apiVersion: "2020-08-27",
   typescript: true
 });
 

--- a/without-webhooks/server/node-typescript/package-lock.json
+++ b/without-webhooks/server/node-typescript/package-lock.json
@@ -677,11 +677,11 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stripe": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.0.1.tgz",
-      "integrity": "sha512-0D9r1YGkrNFmX6RRk34P0uslrOw4cuav1yuJVcxlIwwhh8R06XIqTTPU6/PeGvJ89SUTU/+jny8gFZU0MZ0rpg==",
+      "version": "8.121.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.121.0.tgz",
+      "integrity": "sha512-Uswmut57hVdyPrb+EJUTWbrLcTIEL4LS5T6UQZPO5AJNYT0PGHajgY1esQwmV7yVBL+Kgt3y/16zIAY/gAwifg==",
       "requires": {
-        "@types/node": "^13.1.0",
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       }
     },

--- a/without-webhooks/server/node-typescript/package.json
+++ b/without-webhooks/server/node-typescript/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "stripe": "^8.0.1"
+    "stripe": "^8.121.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/without-webhooks/server/node-typescript/src/server.ts
+++ b/without-webhooks/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import Stripe from "stripe";
 env.config({ path: "./.env" });
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2019-12-03",
+  apiVersion: "2020-08-27",
   typescript: true
 });
 


### PR DESCRIPTION
Hello. It seems `stripe-8.0.1` does not have a property that the app needs on `Stripe.PaymentIntentCreateParams`.  I've fixed it by updating the library to the latest version.

I got the following errors when I tried to compile the app:

```
web_1     | > stripe-sample-accept-a-card-payment@1.0.0 prestart /work/server/node-typescript                                                                                                                        
web_1     | > npm run build                                                                               
web_1     |                                                                                                                                                                                                          
web_1     |                                                                                               
web_1     | > stripe-sample-accept-a-card-payment@1.0.0 build /work/server/node-typescript                
web_1     | > node_modules/typescript/bin/tsc                                                             
web_1     |                                                                                               
web_1     | src/server.ts(63,9): error TS2322: Type '{ amount: number; confirm: true; error_on_requires_action: boolean; currency: string; payment_method: string; }' is not assignable to type 'PaymentIntentCreateParams'.
web_1     |   Object literal may only specify known properties, and 'error_on_requires_action' does not exist in type 'PaymentIntentCreateParams'.
web_1     | npm ERR! code ELIFECYCLE                                                                      
web_1     | npm ERR! errno 2                                                                              
web_1     | npm ERR! stripe-sample-accept-a-card-payment@1.0.0 build: `node_modules/typescript/bin/tsc`   
web_1     | npm ERR! Exit status 2                                                                        
web_1     | npm ERR!                                                                                      
web_1     | npm ERR! Failed at the stripe-sample-accept-a-card-payment@1.0.0 build script.                
web_1     | npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
