### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: 'hibariya/accept-a-card-payment'
-          ref: 'node-typescript-new-api'
+          repository: 'stripe-samples/accept-a-card-payment'
 
       - uses: actions/checkout@v2
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: 'ci'
 
       - name: Install gettext for envsubst
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,14 @@ jobs:
           PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
           BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw
 
+      - name: Collect debug information
+        if: ${{ failure() }}
+        run: |
+          cat docker-compose.yml
+          docker-compose ps -a
+          docker-compose logs web
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+          PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
+          BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI for stripe-samples/accept-a-card-payment
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'hibariya/accept-a-card-payment'
+          ref: 'node-typescript-new-api'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'stripe-samples/sample-ci'
+          path: 'sample-ci'
+          ref: 'ci'
+
+      - name: Install gettext for envsubst
+        run: |
+          sudo apt install gettext-base
+
+      - name: Install jq
+        run: |
+          sudo curl -o /usr/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          sudo chmod +x /usr/bin/jq
+
+      - name: Run tests
+        run: |
+          source sample-ci/helpers.sh
+
+          install_dummy_tests
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+
+          for lang in $(cat .cli.json | server_langs_for_integration decline-on-card-authentication)
+          do
+            [ "$lang" = "php" ] && continue
+
+            configure_docker_compose_for_integration decline-on-card-authentication "$lang" ../../client/web \
+                                                      target/accept-a-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+
+            docker-compose up -d && wait_web_server
+            docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
+          done
+
+          for lang in $(cat .cli.json | server_langs_for_integration using-webhooks)
+          do
+            [ "$lang" = "php" ] && continue
+
+            configure_docker_compose_for_integration using-webhooks "$lang" ../../client/web \
+                                                      target/collecting-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+
+            docker-compose up -d && wait_web_server
+            if [ "$lang" = "java" ]; then
+              docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
+            else
+              docker-compose exec -T -e SERVER_ROOT_PATH=/checkout runner bundle exec rspec spec/server_spec.rb
+            fi
+          done
+
+          for lang in $(cat .cli.json | server_langs_for_integration without-webhooks)
+          do
+            [ "$lang" = "php" ] && continue
+
+            configure_docker_compose_for_integration without-webhooks "$lang" ../../client/web \
+                                                      target/accept-a-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+
+            docker-compose up -d && wait_web_server
+            docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
+          done
+
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+          PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
+          BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw
+

--- a/decline-on-card-authentication/server/node-typescript/package-lock.json
+++ b/decline-on-card-authentication/server/node-typescript/package-lock.json
@@ -677,11 +677,11 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stripe": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.0.1.tgz",
-      "integrity": "sha512-0D9r1YGkrNFmX6RRk34P0uslrOw4cuav1yuJVcxlIwwhh8R06XIqTTPU6/PeGvJ89SUTU/+jny8gFZU0MZ0rpg==",
+      "version": "8.121.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.121.0.tgz",
+      "integrity": "sha512-Uswmut57hVdyPrb+EJUTWbrLcTIEL4LS5T6UQZPO5AJNYT0PGHajgY1esQwmV7yVBL+Kgt3y/16zIAY/gAwifg==",
       "requires": {
-        "@types/node": "^13.1.0",
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       }
     },

--- a/decline-on-card-authentication/server/node-typescript/package.json
+++ b/decline-on-card-authentication/server/node-typescript/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "stripe": "^8.0.1"
+    "stripe": "^8.121.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/decline-on-card-authentication/server/node-typescript/src/server.ts
+++ b/decline-on-card-authentication/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import Stripe from "stripe";
 env.config({ path: "./.env" });
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2019-12-03",
+  apiVersion: "2020-08-27",
   typescript: true
 });
 

--- a/using-webhooks/server/node-typescript/package-lock.json
+++ b/using-webhooks/server/node-typescript/package-lock.json
@@ -82,8 +82,7 @@
     "@types/node": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
-      "dev": true
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -678,19 +677,12 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stripe": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.0.1.tgz",
-      "integrity": "sha512-0D9r1YGkrNFmX6RRk34P0uslrOw4cuav1yuJVcxlIwwhh8R06XIqTTPU6/PeGvJ89SUTU/+jny8gFZU0MZ0rpg==",
+      "version": "8.121.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.121.0.tgz",
+      "integrity": "sha512-Uswmut57hVdyPrb+EJUTWbrLcTIEL4LS5T6UQZPO5AJNYT0PGHajgY1esQwmV7yVBL+Kgt3y/16zIAY/gAwifg==",
       "requires": {
-        "@types/node": "^13.1.0",
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.1.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-          "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
-        }
       }
     },
     "supports-color": {

--- a/using-webhooks/server/node-typescript/package.json
+++ b/using-webhooks/server/node-typescript/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "stripe": "^8.0.1"
+    "stripe": "^8.121.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/using-webhooks/server/node-typescript/src/server.ts
+++ b/using-webhooks/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import express from "express";
 
 import Stripe from "stripe";
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2019-12-03",
+  apiVersion: "2020-08-27",
   typescript: true
 });
 

--- a/without-webhooks/server/node-typescript/package-lock.json
+++ b/without-webhooks/server/node-typescript/package-lock.json
@@ -677,11 +677,11 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stripe": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.0.1.tgz",
-      "integrity": "sha512-0D9r1YGkrNFmX6RRk34P0uslrOw4cuav1yuJVcxlIwwhh8R06XIqTTPU6/PeGvJ89SUTU/+jny8gFZU0MZ0rpg==",
+      "version": "8.121.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.121.0.tgz",
+      "integrity": "sha512-Uswmut57hVdyPrb+EJUTWbrLcTIEL4LS5T6UQZPO5AJNYT0PGHajgY1esQwmV7yVBL+Kgt3y/16zIAY/gAwifg==",
       "requires": {
-        "@types/node": "^13.1.0",
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       }
     },

--- a/without-webhooks/server/node-typescript/package.json
+++ b/without-webhooks/server/node-typescript/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "stripe": "^8.0.1"
+    "stripe": "^8.121.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/without-webhooks/server/node-typescript/src/server.ts
+++ b/without-webhooks/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import Stripe from "stripe";
 env.config({ path: "./.env" });
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2019-12-03",
+  apiVersion: "2020-08-27",
   typescript: true
 });
 


### PR DESCRIPTION
This is similar to https://github.com/stripe-samples/subscription-use-cases/pull/65. I added CI settings that ensure all server implementation can boot or pass existing tests. I also made some changes to run apps on Docker containers. You can confirm that a result of the workflow [here](https://github.com/hibariya/accept-a-card-payment/runs/1417743296?check_suite_focus=true).

Note that this PR needs the following PRs to be merged.

* https://github.com/stripe-samples/sample-ci/pull/1
* https://github.com/stripe-samples/accept-a-card-payment/pull/51