### PR TITLE
Use the same name to let CI run without passing the jar file path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
           do
             [ "$lang" = "php" ] && continue
 
-            configure_docker_compose_for_integration decline-on-card-authentication "$lang" ../../client/web \
-                                                      target/accept-a-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration decline-on-card-authentication "$lang" ../../client/web
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
           done
@@ -44,9 +42,7 @@ jobs:
           do
             [ "$lang" = "php" ] && continue
 
-            configure_docker_compose_for_integration using-webhooks "$lang" ../../client/web \
-                                                      target/collecting-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration using-webhooks "$lang" ../../client/web
             docker-compose up -d && wait_web_server
             if [ "$lang" = "java" ]; then
               docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
@@ -59,9 +55,7 @@ jobs:
           do
             [ "$lang" = "php" ] && continue
 
-            configure_docker_compose_for_integration without-webhooks "$lang" ../../client/web \
-                                                      target/accept-a-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration without-webhooks "$lang" ../../client/web
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI for stripe-samples/accept-a-card-payment
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/decline-on-card-authentication/server/java/README.md
+++ b/decline-on-card-authentication/server/java/README.md
@@ -14,7 +14,7 @@ mvn package
 2. Run the packaged jar
 
 ```
-java -cp target/accept-a-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/decline-on-card-authentication/server/java/pom.xml
+++ b/decline-on-card-authentication/server/java/pom.xml
@@ -18,7 +18,7 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/using-webhooks/server/java/README.md
+++ b/using-webhooks/server/java/README.md
@@ -14,7 +14,7 @@ mvn package
 2. Run the packaged jar
 
 ```
-java -cp target/collecting-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/using-webhooks/server/java/pom.xml
+++ b/using-webhooks/server/java/pom.xml
@@ -18,7 +18,7 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/without-webhooks/server/java/README.md
+++ b/without-webhooks/server/java/README.md
@@ -14,7 +14,7 @@ mvn package
 2. Run the packaged jar
 
 ```
-java -cp target/accept-a-card-payment-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/without-webhooks/server/java/pom.xml
+++ b/without-webhooks/server/java/pom.xml
@@ -18,7 +18,7 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As described in https://github.com/stripe-samples/sample-ci/pull/2, I changed the jar file names to the same one. 
