### PR TITLE
Recommend stripe vscode extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .DS_Store
-.vscode
+.vscode/*
+!.vscode/extensions.json
 
 # Node files
 node_modules/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["stripe.vscode-stripe"]
+}


### PR DESCRIPTION
Add a `.vscode/extensions.json` file that [magically recommends](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) the [Stripe VS Code extension](https://marketplace.visualstudio.com/items?itemName=Stripe.vscode-stripe) to users who open the sample in VS Code. I verified locally that the extension is recommended to me.

ptal @cjavilla-stripe. You mentioned in slack that it's okay to commit to master directly, but I'd like a review on this first one at least. Afterwards I'll be comfortable pushing to master for the other samples.

Motivation: https://github.com/stripe/vscode-stripe/issues/157