### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
           install_docker_compose_settings
           export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
-          export COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.selenium.yml
+          export COMPOSE_FILE=docker-compose.yml:docker-compose.selenium.yml
           echo "SELENIUM_URL=http://selenium:4444/wd/hub" >> .env
 
           for lang in $(cat .cli.json | server_langs_for_integration decline-on-card-authentication)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ env
 # PHP files
 vendor
 logs
+composer.lock
 
 # Java files
 .settings

--- a/decline-on-card-authentication/server/php-slim/composer.json
+++ b/decline-on-card-authentication/server/php-slim/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "slim/slim": "^3.12",
         "vlucas/phpdotenv": "^3.4",
-        "stripe/stripe-php": "^6.31",
+        "stripe/stripe-php": "^7.78.0",
         "monolog/monolog": "^1.17"
     },
     "scripts": {

--- a/decline-on-card-authentication/server/php-slim/index.php
+++ b/decline-on-card-authentication/server/php-slim/index.php
@@ -20,8 +20,7 @@ $app = new \Slim\App;
 // Instantiate the logger as a dependency
 $container = $app->getContainer();
 $container['logger'] = function ($c) {
-  $settings = $c->get('settings')['logger'];
-  $logger = new Monolog\Logger($settings['name']);
+  $logger = new Monolog\Logger('app');
   $logger->pushProcessor(new Monolog\Processor\UidProcessor());
   $logger->pushHandler(new Monolog\Handler\StreamHandler(__DIR__ . '/logs/app.log', \Monolog\Logger::DEBUG));
   return $logger;
@@ -69,9 +68,9 @@ $app->post('/pay', function (Request $request, Response $response) use ($app) {
 
     // Send the client secret to the client to use in the demo
     return $response->withJson(['clientSecret' => $intent->client_secret]);
-  } catch (\Stripe\Error\Card $e) {
+  } catch (\Stripe\Exception\CardException $e) {
     # Display error on client
-    if ($e->getCode() == 'authentication_required') {
+    if ($e->getDeclineCode() == 'authentication_required') {
       return $response->withJson([
         'error' => 'This card requires authentication in order to proceeded. Please use a different card'
       ]);

--- a/decline-on-card-authentication/server/php/composer.json
+++ b/decline-on-card-authentication/server/php/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "stripe/stripe-php": "^6.31"
+        "stripe/stripe-php": "^7.78.0"
     }
 }

--- a/decline-on-card-authentication/server/php/public/pay.php
+++ b/decline-on-card-authentication/server/php/public/pay.php
@@ -22,11 +22,11 @@ try {
 
   // Send the client secret to the client to use in the demo
   echo json_encode(['clientSecret' => $intent->client_secret]);
-} catch (\Stripe\Error\Card $e) {
-  if ($e->getCode() == 'authentication_required') {
+} catch (\Stripe\Exception\CardException $e) {
+  if ($e->getDeclineCode() == 'authentication_required') {
     echo json_encode([
       'error' => 'This card requires authentication in order to proceeded. Please use a different card'
-    ]);  
+    ]);
   } else {
     echo json_encode([
       'error' => $e->getMessage()

--- a/spec/decline_on_card_authentication_spec.rb
+++ b/spec/decline_on_card_authentication_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Decline on card authentication", type: :system do
 
     click_on "Pay"
 
+    expect(page).to have_no_selector "#card-errors"
     expect(page).to have_content "Payment completed"
   end
 
@@ -30,6 +31,6 @@ RSpec.describe "Decline on card authentication", type: :system do
     click_on "Pay"
 
     expect(page).to have_no_content "Payment completed"
-    expect(page).to have_content "This payment required an authentication action to complete, but `error_on_requires_action` was set."
+    expect(page).to have_selector "#card-errors"
   end
 end

--- a/spec/decline_on_card_authentication_spec.rb
+++ b/spec/decline_on_card_authentication_spec.rb
@@ -1,4 +1,5 @@
 require 'capybara_support'
+require 'byebug'
 
 RSpec.describe "Decline on card authentication", type: :system do
   example "With a valid card, the payment should be completed successfully" do
@@ -29,6 +30,6 @@ RSpec.describe "Decline on card authentication", type: :system do
     click_on "Pay"
 
     expect(page).to have_no_content "Payment completed"
-    expect(page).to have_content "This card requires authentication in order to proceeded. Please use a different card"
+    expect(page).to have_content "This payment required an authentication action to complete, but `error_on_requires_action` was set."
   end
 end

--- a/spec/decline_on_card_authentication_spec.rb
+++ b/spec/decline_on_card_authentication_spec.rb
@@ -1,5 +1,4 @@
 require 'capybara_support'
-require 'byebug'
 
 RSpec.describe "Decline on card authentication", type: :system do
   example "With a valid card, the payment should be completed successfully" do

--- a/using-webhooks/server/php-slim/composer.json
+++ b/using-webhooks/server/php-slim/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "slim/slim": "^3.12",
         "vlucas/phpdotenv": "^3.4",
-        "stripe/stripe-php": "^6.31",
+        "stripe/stripe-php": "^7.78.0",
         "monolog/monolog": "^1.17"
     },
     "scripts": {

--- a/using-webhooks/server/php-slim/index.php
+++ b/using-webhooks/server/php-slim/index.php
@@ -19,8 +19,7 @@ $app = new \Slim\App;
 // Instantiate the logger as a dependency
 $container = $app->getContainer();
 $container['logger'] = function ($c) {
-  $settings = $c->get('settings')['logger'];
-  $logger = new Monolog\Logger($settings['name']);
+  $logger = new Monolog\Logger('app');
   $logger->pushProcessor(new Monolog\Processor\UidProcessor());
   $logger->pushHandler(new Monolog\Handler\StreamHandler(__DIR__ . '/logs/app.log', \Monolog\Logger::DEBUG));
   return $logger;
@@ -31,7 +30,7 @@ $app->add(function ($request, $response, $next) {
     return $next($request, $response);
 });
 
-$app->get('/checkout', function (Request $request, Response $response, array $args) {   
+$app->get('/checkout', function (Request $request, Response $response, array $args) {
   // Display checkout page
   return $response->write(file_get_contents(getenv('STATIC_DIR') . '/index.html'));
 });
@@ -53,7 +52,7 @@ $app->post('/create-payment-intent', function (Request $request, Response $respo
       "amount" => calculateOrderAmount($body->items),
       "currency" => $body->currency
     ]);
-    
+
     // Send publishable key and PaymentIntent details to client
     return $response->withJson(array('publishableKey' => $pub_key, 'clientSecret' => $payment_intent->client_secret));
 });
@@ -78,7 +77,7 @@ $app->post('/webhook', function(Request $request, Response $response) {
     }
     $type = $event['type'];
     $object = $event['data']['object'];
-    
+
     if ($type == 'payment_intent.succeeded') {
       // Fulfill any orders, e-mail receipts, etc
       // To cancel the payment you will need to issue a Refund (https://stripe.com/docs/api/refunds)

--- a/using-webhooks/server/php/composer.json
+++ b/using-webhooks/server/php/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "stripe/stripe-php": "^6.31"
+        "stripe/stripe-php": "^7.78.0"
     }
 }

--- a/without-webhooks/server/php-slim/composer.json
+++ b/without-webhooks/server/php-slim/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "slim/slim": "^3.12",
         "vlucas/phpdotenv": "^3.4",
-        "stripe/stripe-php": "^6.31",
+        "stripe/stripe-php": "^7.78.0",
         "monolog/monolog": "^1.17"
     },
     "scripts": {

--- a/without-webhooks/server/php/composer.json
+++ b/without-webhooks/server/php/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "stripe/stripe-php": "^6.31"
+        "stripe/stripe-php": "^7.78.0"
     }
 }

--- a/without-webhooks/server/php/public/pay.php
+++ b/without-webhooks/server/php/public/pay.php
@@ -9,7 +9,7 @@ function calculateOrderAmount($items) {
 	return 1400;
 }
 
-function generateResponse($intent) 
+function generateResponse($intent)
 {
   switch($intent->status) {
     case "requires_action":
@@ -44,7 +44,7 @@ try {
       "confirm" => true,
       // If a mobile client passes `useStripeSdk`, set `use_stripe_sdk=true`
       // to take advantage of new authentication features in mobile SDKs
-      "use_stripe_sdk" => $body->useStripeSdk,
+      "use_stripe_sdk" => isset($body->useStripeSdk) ? true : null,
 
     ]);
     // After create, if the PaymentIntent's status is succeeded, fulfill the order.
@@ -54,11 +54,11 @@ try {
     $intent = \Stripe\PaymentIntent::retrieve($body->paymentIntentId);
     $intent->confirm();
     // After confirm, if the PaymentIntent's status is succeeded, fulfill the order.
-  }  
+  }
   $output = generateResponse($intent);
 
   echo json_encode($output);
-} catch (\Stripe\Error\Card $e) {
+} catch (\Stripe\Exception\CardException $e) {
   echo json_encode([
     'error' => $e->getMessage()
   ]);


### PR DESCRIPTION
@cjavilla-stripe CI is failing for several reasons after merging #54 :pray:  To fix it, I added the following changes:

## 1. Fix COMPOSE_FILE

Removed `docker-compose.override.yml` from `COMPOSE_FILE` as we no longer need it for CI after https://github.com/stripe-samples/sample-ci/pull/10.

## 2. Complete bundle-install in advance

:arrow_right: See https://github.com/stripe-samples/sample-ci/pull/11

## 3. Update stripe-php to the latest version

Updated stripe-php to 7.78.0 since the older version (6.31) causes an error like this: https://github.com/hibariya/accept-a-card-payment/runs/2514552286?check_suite_focus=true#step:6:105

<details>
<summary>Error message</summary>
<pre>
web_1     | Type: TypeError
web_1     | Message: array_key_exists(): Argument #2 ($array) must be of type array, Stripe\Util\CaseInsensitiveArray given
web_1     | File: /work/decline-on-card-authentication/server/php-slim/vendor/stripe/stripe-php/lib/ApiRequestor.php
web_1     | Line: 402
web_1     | Trace: #0 /work/decline-on-card-authentication/server/php-slim/vendor/stripe/stripe-php/lib/ApiRequestor.php(402): array_key_exists('request-id', Object(Stripe\Util\CaseInsensitiveArray))
web_1     | #1 /work/decline-on-card-authentication/server/php-slim/vendor/stripe/stripe-php/lib/ApiRequestor.php(125): Stripe\ApiRequestor->_requestRaw('post', '/v1/payment_int...', Array, Array)
web_1     | #2 /work/decline-on-card-authentication/server/php-slim/vendor/stripe/stripe-php/lib/ApiOperations/Request.php(57): Stripe\ApiRequestor->request('post', '/v1/payment_int...', Array, Array)
web_1     | #3 /work/decline-on-card-authentication/server/php-slim/vendor/stripe/stripe-php/lib/ApiOperations/Create.php(23): Stripe\ApiResource::_staticRequest('post', '/v1/payment_int...', Array, NULL)
web_1     | #4 /work/decline-on-card-authentication/server/php-slim/index.php(59): Stripe\PaymentIntent::create(Array)
web_1     | #5 [internal function]: Closure->{closure}(Object(Slim\Http\Request), Object(Slim\Http\Response), Array)
web_1     | #6 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/Handlers/Strategies/RequestResponse.php(40): call_user_func(Object(Closure), Object(Slim\Http\Request), Object(Slim\Http\Response), Array)
web_1     | #7 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/Route.php(281): Slim\Handlers\Strategies\RequestResponse->__invoke(Object(Closure), Object(Slim\Http\Request), Object(Slim\Http\Response), Array)
web_1     | #8 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(117): Slim\Route->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #9 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/Route.php(268): Slim\Route->callMiddlewareStack(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #10 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/App.php(503): Slim\Route->run(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #11 /work/decline-on-card-authentication/server/php-slim/index.php(32): Slim\App->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #12 [internal function]: Closure->{closure}(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\App))
web_1     | #13 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/DeferredCallable.php(57): call_user_func_array(Object(Closure), Array)
web_1     | #14 [internal function]: Slim\DeferredCallable->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\App))
web_1     | #15 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(70): call_user_func(Object(Slim\DeferredCallable), Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\App))
web_1     | #16 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(117): Slim\App->Slim\{closure}(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #17 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/App.php(392): Slim\App->callMiddlewareStack(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #18 /work/decline-on-card-authentication/server/php-slim/vendor/slim/slim/Slim/App.php(297): Slim\App->process(Object(Slim\Http\Request), Object(Slim\Http\Response))
web_1     | #19 /work/decline-on-card-authentication/server/php-slim/index.php(86): Slim\App->run()
web_1     | #20 {main}
</pre>
</details>

I'm not sure why this occurred with that version. Does it relevant to the API version? 

## 4. Fix warning messages

These warning messages are appended to the response body and that causes errors on the front-end when parsing it as a JSON.

1. Since `$c->get('settings')['logger']` was `NULL`, I changed not to use it for the logger's name.
2. Changed to use `isset` because `$body->useStripeSdk` could be undefined.

## 5. Update exception handlings

Added some changes to make the apps compatible with the newer stripe-php, such as renaming `\Stripe\Error\Card` to `\Stripe\Exception\CardException`.